### PR TITLE
Travis coverage (#2)

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -3,9 +3,7 @@ name: Lint
 on:
   push:
     branches:
-      - development
-      - master
-      - github-actions
+      - '*'
   pull_request:
     branches:
       - development

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+python:
+- '3.7'
+- '3.8'
+install:
+- pip install -r requirements.txt
+- pip install -r requirements/test.txt
+- pip install .
+cache:
+- pip
+script:
+- pytest -vx -k mnist --cov=backobs test
+after_success:
+- coveralls
+notifications:
+  email: false
+  slack:
+    secure: F/zplm2kjK06yZorkvKFf+2bGhmsKzi3uZQJarZFQHZLIIkBQGVzTIWdOBlJdH4Xjt9FMH9a4ZuRpEco6YewxKWYFl5gkbjoHuNu2ZqoXRhOiNc/vxVO53pYKS4M8JgyJLdsz2H9TipL0Gx0dJ3yBHIx8t+FOSpErrwT108luvkZFYVj79ArTmD5rKE9ViUodkfnBUHIEhqegLAF0Xow4PR5UuvM8IbKxnjtli21dNpMCUWW97DKZ4NTsfKXbDq9yi4MD8p3RR9MD9jQ4I4lVsfziInmhk6BiVi6dmDAg1xmtgcDkkOo9Ug0/hsPrZi1mYdCmVmd0R6sCTFZJvlD7zUNHePqGyKVyAjqt0C1hrvoxtKg1uzXYxPYuGFHerTqYM+SHTVHfK7BB6yy84/MJfbTKTuy/iDqz3hKAKbz4wokVw1FcPCj1riP8GdwHOjibhyHHLPie5VH1s4YkA3H54Nx7oS/PhEJ9AjOjPdFB16lCziujirVZFq3TJKLtum8300re0P7aDizL9jWy4SepKXUAwyCFia28YfEkNrUF/lsH0ypcB3mh88TnsfsSVTGQVBmr2bfUmd3RVjdy6tviYSHcA4yXDsl9GkqfY6bRMDtC2h43EOqgJxIH3claLSjbN4d2IpaVkh2ZsWoI+3r1WbwoM1ASNRTTBgWI5dnasA=
+    on_success: never

--- a/README.org
+++ b/README.org
@@ -4,7 +4,13 @@
 #+author: F. Dangel
 
 * BackOBS = [[https://www.backpack.pt][BackPACK]] + [[https://github.com/fsschneider/DeepOBS][DeepOBS]]
-BackOBS allows you to use [[https://www.backpack.pt][BackPACK]] on [[https://github.com/fsschneider/DeepOBS][DeepOBS]] testproblems (in a limiting way, see details below).
+
+[[https://travis-ci.org/f-dangel/backobs][https://travis-ci.org/f-dangel/backobs.svg?branch=master]]
+[[https://coveralls.io/github/f-dangel/backobs][https://coveralls.io/repos/github/f-dangel/backobs/badge.svg?branch=master]]
+[[https://www.python.org/downloads/release/python-370/][https://img.shields.io/badge/python-3.7+-blue.svg]]
+
+
+BackOBS allows you to use [[https://www.backpack.pt][BackPACK]] on [[https://github.com/fsschneider/DeepOBS][DeepOBS]] testproblems (in a limiting way, see details below)
 
 ⚠ The package and its API are experimental. Beware of rough edges!
 

--- a/requirements/test.txt
+++ b/requirements/test.txt
@@ -1,2 +1,3 @@
 pytest
 pytest-cov
+coveralls


### PR DESCRIPTION
* Add travis.yml

* Relax python>=3.7 → >=3.6

* Dont' post to slack on success

* Lint commits pushed to any branch

* Remove python 3.6 (nullcontext introduced in python 3.7)

* Add badges for travis, coverage, python version

* Add coveralls

Co-authored-by: F. Dangel <fdangel@tuebingen.mpg.de>